### PR TITLE
Refactor generating migrations

### DIFF
--- a/spec/amber/cli/templates/crecto_migration_spec.cr
+++ b/spec/amber/cli/templates/crecto_migration_spec.cr
@@ -14,8 +14,23 @@ module Amber::CLI
             SQL
           migration_text.should contain create_index_line
         end
-
       end
+
+      context "pg" do
+        migration = MigrationSpecHelper.sample_migration_for(CrectoMigration)
+        migration_text = MigrationSpecHelper.text_for(migration)
+        migrate_up_text = MigrationSpecHelper.sample_migration_migrate_up_text_pg
+        migrate_down_text = MigrationSpecHelper.sample_migration_migrate_down_text_pg
+
+        it "should contain correct CREATE TABLE statement" do
+          migration_text.should contain migrate_up_text
+        end
+
+        it "should contain correct DROP TABLE statement" do
+          migration_text.should contain migrate_down_text
+        end
+      end
+
     end
   end
 end

--- a/spec/amber/cli/templates/crecto_migration_spec.cr
+++ b/spec/amber/cli/templates/crecto_migration_spec.cr
@@ -5,29 +5,32 @@ module Amber::CLI
   describe CrectoMigration do
     describe "#render" do
       context "when rendering a migration with an index for belongs_to" do
-        migration = GraniteMigration.new("post", ["user:ref", "title:string"])
+        migration = MigrationSpecHelper.sample_migration_for(CrectoMigration)
         migration_text = MigrationSpecHelper.text_for(migration)
 
         it "create the index with proper naming convention" do
-          create_index_line = <<-SQL
-            CREATE INDEX post_user_id_idx ON posts (user_id)
-            SQL
-          migration_text.should contain create_index_line
+          create_index_sql = MigrationSpecHelper.sample_migration_create_index_sql
+          migration_text.should contain create_index_sql
         end
       end
 
       context "pg" do
-        migration = MigrationSpecHelper.sample_migration_for(CrectoMigration)
+        migration = MigrationSpecHelper.sample_migration_for(GraniteMigration)
         migration_text = MigrationSpecHelper.text_for(migration)
-        migrate_up_text = MigrationSpecHelper.sample_migration_migrate_up_text_pg
-        migrate_down_text = MigrationSpecHelper.sample_migration_migrate_down_text_pg
 
         it "should contain correct CREATE TABLE statement" do
-          migration_text.should contain migrate_up_text
+          create_table_sql = MigrationSpecHelper.sample_migration_create_table_sql_pg
+          migration_text.should contain create_table_sql
+        end
+
+        it "should contain correct CREATE INDEX statement" do
+          create_index_sql = MigrationSpecHelper.sample_migration_create_index_sql
+          migration_text.should contain create_index_sql
         end
 
         it "should contain correct DROP TABLE statement" do
-          migration_text.should contain migrate_down_text
+          drop_table_sql = MigrationSpecHelper.sample_migration_drop_table_sql
+          migration_text.should contain drop_table_sql
         end
       end
 

--- a/spec/amber/cli/templates/granite_migration_spec.cr
+++ b/spec/amber/cli/templates/granite_migration_spec.cr
@@ -5,14 +5,12 @@ module Amber::CLI
   describe GraniteMigration do
     describe "#render" do
       context "when rendering a migration with an index for belongs_to" do
-        migration = GraniteMigration.new("post", ["user:ref", "title:string"])
+        migration = MigrationSpecHelper.sample_migration_for(GraniteMigration)
         migration_text = MigrationSpecHelper.text_for(migration)
 
         it "create the index with proper naming convention" do
-          create_index_line = <<-SQL
-            CREATE INDEX post_user_id_idx ON posts (user_id)
-            SQL
-          migration_text.should contain create_index_line
+          create_index_sql = MigrationSpecHelper.sample_migration_create_index_sql
+          migration_text.should contain create_index_sql
         end
 
       end
@@ -20,18 +18,23 @@ module Amber::CLI
       context "pg" do
         migration = MigrationSpecHelper.sample_migration_for(GraniteMigration)
         migration_text = MigrationSpecHelper.text_for(migration)
-        migrate_up_text = MigrationSpecHelper.sample_migration_migrate_up_text_pg
-        migrate_down_text = MigrationSpecHelper.sample_migration_migrate_down_text_pg
 
         it "should contain correct CREATE TABLE statement" do
-          migration_text.should contain migrate_up_text
+          create_table_sql = MigrationSpecHelper.sample_migration_create_table_sql_pg
+          migration_text.should contain create_table_sql
+        end
+
+        it "should contain correct CREATE INDEX statement" do
+          create_index_sql = MigrationSpecHelper.sample_migration_create_index_sql
+          migration_text.should contain create_index_sql
         end
 
         it "should contain correct DROP TABLE statement" do
-          migration_text.should contain migrate_down_text
+          drop_table_sql = MigrationSpecHelper.sample_migration_drop_table_sql
+          migration_text.should contain drop_table_sql
         end
       end
-      
+
     end
   end
 end

--- a/spec/amber/cli/templates/granite_migration_spec.cr
+++ b/spec/amber/cli/templates/granite_migration_spec.cr
@@ -16,6 +16,22 @@ module Amber::CLI
         end
 
       end
+
+      context "pg" do
+        migration = MigrationSpecHelper.sample_migration_for(GraniteMigration)
+        migration_text = MigrationSpecHelper.text_for(migration)
+        migrate_up_text = MigrationSpecHelper.sample_migration_migrate_up_text_pg
+        migrate_down_text = MigrationSpecHelper.sample_migration_migrate_down_text_pg
+
+        it "should contain correct CREATE TABLE statement" do
+          migration_text.should contain migrate_up_text
+        end
+
+        it "should contain correct DROP TABLE statement" do
+          migration_text.should contain migrate_down_text
+        end
+      end
+      
     end
   end
 end

--- a/spec/amber/cli/templates/migration_spec.cr
+++ b/spec/amber/cli/templates/migration_spec.cr
@@ -1,0 +1,35 @@
+require "../../../spec_helper"
+require "./migration_spec_helper"
+
+module Amber::CLI
+  describe Migration do
+    migration = MigrationSpecHelper.sample_migration_for(Migration)
+
+    describe "#create_index_for_reference_fields_sql" do
+      it "return the correct CREATE INDEX sql string" do
+        expected = MigrationSpecHelper.sample_migration_create_index_sql
+        actual = migration.create_index_for_reference_fields_sql
+        actual.should eq expected
+      end
+    end
+
+    context "pg" do
+
+      describe "#create_table_sql" do
+        it "should return the correct CREATE TABLE statement" do
+          create_table_sql = MigrationSpecHelper.sample_migration_create_table_sql_pg
+          migration.create_table_sql.should eq create_table_sql
+        end
+      end
+
+      describe "#drop_table_sql" do
+        it "should return the correct DROP TABLE statement" do
+          drop_table_sql = MigrationSpecHelper.sample_migration_drop_table_sql
+          migration.drop_table_sql.should eq drop_table_sql
+        end
+      end
+
+    end
+
+  end
+end

--- a/spec/amber/cli/templates/migration_spec_helper.cr
+++ b/spec/amber/cli/templates/migration_spec_helper.cr
@@ -17,7 +17,7 @@ module Amber::CLI
       migration_template_type.new("post", ["user:ref", "title:string", "body:text"])
     end
 
-    def self.sample_migration_migrate_up_text_pg
+    def self.sample_migration_create_table_sql_pg
       <<-SQL
       CREATE TABLE posts (
         id BIGSERIAL PRIMARY KEY,
@@ -30,7 +30,11 @@ module Amber::CLI
       SQL
     end
 
-    def self.sample_migration_migrate_down_text_pg
+    def self.sample_migration_create_index_sql
+      "CREATE INDEX post_user_id_idx ON posts (user_id);"
+    end
+
+    def self.sample_migration_drop_table_sql
       "DROP TABLE IF EXISTS posts;"
     end
 

--- a/spec/amber/cli/templates/migration_spec_helper.cr
+++ b/spec/amber/cli/templates/migration_spec_helper.cr
@@ -2,11 +2,36 @@ module Amber::CLI
   module MigrationSpecHelper
 
     def self.text_for(migration : Migration) : String
-      migration.render("./tmp")
-      migration_filename = Dir.entries("./tmp/db/migrations").sort.last
-      migration_text = File.read("./tmp/db/migrations/#{migration_filename}")
-      `rm -rf ./tmp/db`
+      migration_text = ""
+      begin
+        migration.render("./tmp")
+        migration_filename = Dir.entries("./tmp/db/migrations").sort.last
+        migration_text = File.read("./tmp/db/migrations/#{migration_filename}")
+      ensure
+        `rm -rf ./tmp/db`
+      end
       return migration_text
+    end
+
+    def self.sample_migration_for(migration_template_type)
+      migration_template_type.new("post", ["user:ref", "title:string", "body:text"])
+    end
+
+    def self.sample_migration_migrate_up_text_pg
+      <<-SQL
+      CREATE TABLE posts (
+        id BIGSERIAL PRIMARY KEY,
+        user_id BIGINT,
+        title VARCHAR,
+        body TEXT,
+        created_at TIMESTAMP,
+        updated_at TIMESTAMP
+      );
+      SQL
+    end
+
+    def self.sample_migration_migrate_down_text_pg
+      "DROP TABLE IF EXISTS posts;"
     end
 
   end

--- a/src/amber/cli/templates/migration.cr
+++ b/src/amber/cli/templates/migration.cr
@@ -30,6 +30,15 @@ module Amber::CLI
       sql_statements.join("\n")
     end
 
+    def create_table_sql
+      <<-SQL
+      CREATE TABLE #{@name}s (
+        #{@primary_key},
+        #{create_table_fields_sql}
+      );
+      SQL
+    end
+
     def database
       if File.exists?(AMBER_YML) &&
          (yaml = YAML.parse(File.read AMBER_YML)) &&
@@ -38,6 +47,10 @@ module Amber::CLI
       else
         return "pg"
       end
+    end
+
+    def drop_table_sql
+      "DROP TABLE IF EXISTS #{@name}s;"
     end
 
     def primary_key
@@ -58,6 +71,14 @@ module Amber::CLI
       <<-SQL
       CREATE INDEX #{index_name} ON #{@name}s (#{field.name}_id);
       SQL
+    end
+
+    private def create_table_field_sql(field : Field)
+      "#{field.name}#{field.reference? ? "_id" : ""} #{field.db_type}"
+    end
+
+    private def create_table_fields_sql
+      @fields.map{|field| create_table_field_sql(field) }.join(",\n  ")
     end
 
     private def reference_fields

--- a/src/amber/cli/templates/migration/crecto/db/migrations/{{timestamp}}_create_{{name}}.sql.ecr
+++ b/src/amber/cli/templates/migration/crecto/db/migrations/{{timestamp}}_create_{{name}}.sql.ecr
@@ -1,9 +1,6 @@
 -- +micrate Up
-CREATE TABLE <%= @name %>s (
-  <%= @primary_key %>,
-  <%= @fields.map{ |field| "#{field.name}#{field.reference? ? "_id" : ""} #{field.db_type}" }.join(",\n  ") %>
-);
-<%= create_index_for_reference_fields_sql %> 
+<%= create_table_sql %>
+<%= create_index_for_reference_fields_sql %>
 
 -- +micrate Down
-DROP TABLE IF EXISTS <%= @name %>s;
+<%= drop_table_sql %>

--- a/src/amber/cli/templates/migration/granite/db/migrations/{{timestamp}}_create_{{name}}.sql.ecr
+++ b/src/amber/cli/templates/migration/granite/db/migrations/{{timestamp}}_create_{{name}}.sql.ecr
@@ -1,9 +1,6 @@
 -- +micrate Up
-CREATE TABLE <%= @name %>s (
-  <%= @primary_key %>,
-  <%= @fields.map{ |field| "#{field.name}#{field.reference? ? "_id" : ""} #{field.db_type}" }.join(",\n  ") %>
-);
-<%= create_index_for_reference_fields_sql %> 
+<%= create_table_sql %>
+<%= create_index_for_reference_fields_sql %>
 
 -- +micrate Down
-DROP TABLE IF EXISTS <%= @name %>s;
+<%= drop_table_sql %>


### PR DESCRIPTION
### Description of the Change

Refactors the generation of migrations - the syntax is currently identical between crecto and granite, this puts the code to generate that identical sql in one place.

### Alternate Designs

None considered.

### Benefits

Only have to add/change code in one place for migration generation. Also, there are some tests now to make sure the CREATE TABLE sql is generated correctly for pg.

### Possible Drawbacks

There shouldn't be any. There are still two separate ecr files for the different ORMs, so if they need to be customized in the future, they can be.
